### PR TITLE
Add support for NixOS using flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,70 @@ Currently, Bibli supports `bibfile` and `zotero_api` backends.
 
   - [More on setting up citation keys for online libraries](/docs/custom-cite-keys.md)
 
+
+## Using Nix
+
+### Installation via Flakes
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    bibli-ls.url = "github:kha-dinh/bibli-ls";
+  };
+}
+```
+
+Then you can use it in your configuration:
+
+```nix
+{
+  environment.systemPackages = [ inputs.bibli-ls.packages.${system}.default ];
+}
+```
+
+### Home Manager Configuration
+
+Add bibli-ls to your home-manager configuration:
+
+```nix
+{ config, pkgs, inputs, ... }:
+{
+  home.packages = [ inputs.bibli-ls.packages.${system}.default ];
+
+  home.file."Sync/Notes/zk/permanent/.bibli.toml".text = ''
+    [backends]
+    [backends.library]
+    backend_type = "bibfile"
+    bibfiles = ["${config.home.homeDirectory}/Sync/Bibliography/library.bib"]
+  '';
+}
+```
+
+### Updating Dependencies
+
+The flake.nix file contains Python package dependencies with their specific versions and hashes. To update a dependency:
+
+1. Find the new wheel URL from PyPI
+2. Update the version and URL in flake.nix
+3. Update the SHA256 hash. You can get the new hash by intentionally using a wrong hash and Nix will tell you the correct one:
+
+```bash
+nix build # Will fail and show the correct hash
+```
+
+Example of updating a dependency in flake.nix:
+
+```nix
+pygls = buildWheel {
+  pname = "pygls";
+  version = "2.0.0a2"; # Update version
+  url = "https://files.pythonhosted.org/packages/..."; # Update URL
+  sha256 = "sha256-..."; # Update hash
+  propagatedBuildInputs = [ lsprotocol ];
+};
+```
+
 ## Building from source
 
 From the root directory:
@@ -112,6 +176,6 @@ From the root directory:
 pip install . # --force-reinstall if needed
 # Or for Arch
 pipx install . # --force-reinstall if needed
-
-
+# And Nix
+nix build # The built package will be available in `./result`.
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,184 +17,157 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        bibtexparser2 = pkgs.python3Packages.buildPythonPackage {
-          pname = "bibtexparser";
-          version = "2.0.0b4";
-          format = "wheel";
+        # Helper function for wheel packages
+        buildWheel =
+          {
+            pname,
+            version,
+            url,
+            sha256,
+            propagatedBuildInputs ? [ ],
+          }:
+          pkgs.python3Packages.buildPythonPackage {
+            inherit pname version propagatedBuildInputs;
+            format = "wheel";
+            src = pkgs.fetchurl {
+              inherit url sha256;
+            };
+            doCheck = false;
+          };
 
-          src = pkgs.fetchurl {
+        # Custom Python packages
+        customPythonPackages = with pkgs.python3Packages; {
+          bibtexparser2 = buildWheel {
+            pname = "bibtexparser";
+            version = "2.0.0b4";
             url = "https://files.pythonhosted.org/packages/3f/64/6eda019a3b0d3aa6834865c126b66cfd442f56829befdca571c40662f8a6/bibtexparser-2.0.0b4-py3-none-any.whl";
             sha256 = "sha256-FOWMfvltp4z2dce7LPFbA2E9Rj737c09ruIPU7SJzoM=";
+            propagatedBuildInputs = [ pylatexenc ];
           };
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            pylatexenc
-          ];
-
-          doCheck = false;
-        };
-
-        pyzotero = pkgs.python3Packages.buildPythonPackage {
-          pname = "pyzotero";
-          version = "1.5.25";
-          format = "wheel";
-
-          src = pkgs.fetchurl {
+          pyzotero = buildWheel {
+            pname = "pyzotero";
+            version = "1.5.25";
             url = "https://files.pythonhosted.org/packages/cb/3c/717f90930fbba6ec433a8b6eb9c8854089b7cd54118fb3dd5822d53bdfc7/pyzotero-1.5.25-py3-none-any.whl";
             sha256 = "sha256-ZSkTDLfH53OWPZLbfnoYtpipesgVZ2YyC1Xr1MfpTtU=";
+            propagatedBuildInputs = [
+              # bibtexparser2
+              feedparser
+              pytz
+              requests
+            ];
           };
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            bibtexparser2
-            feedparser
-            pytz
-            requests
-          ];
-
-          doCheck = false;
-        };
-
-        py-markdown-table = pkgs.python3Packages.buildPythonPackage {
-          pname = "py-markdown-table";
-          version = "1.2.0";
-          format = "pyproject";
-
-          src = pkgs.fetchPypi {
-            pname = "py_markdown_table";
-            version = "1.2.0";
-            sha256 = "sha256-uuMMqX274UT/phiXlsi+1kWV6kyqTUI3nhFY3Y0myHM=";
-          };
-
-          nativeBuildInputs = with pkgs.python3Packages; [
-            poetry-core
-          ];
-
-          propagatedBuildInputs = with pkgs.python3Packages; [
-          ];
-
-          doCheck = false;
-        };
-
-        tosholi = pkgs.python3Packages.buildPythonPackage {
-          pname = "tosholi";
-          version = "0.1.0";
-          format = "pyproject";
-
-          src = pkgs.fetchPypi {
-            pname = "tosholi";
-            version = "0.1.0";
-            sha256 = "sha256-MmykuNgxCzKvmei+c6O2Yosw88i027jnvGDkKiWpGlI=";
-          };
-
-          nativeBuildInputs = with pkgs.python3Packages; [
-            setuptools
-            setuptools_scm
-          ];
-
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            dacite
-            tomli-w
-          ];
-
-          doCheck = false;
-        };
-
-        ripgrepy = pkgs.python3Packages.buildPythonPackage {
-          pname = "ripgrepy";
-          version = "2.0.0";
-          format = "setuptools";
-
-          src = pkgs.fetchPypi {
-            pname = "ripgrepy";
-            version = "2.0.0";
-            sha256 = "sha256-bdhxuv6FkwEJc1TR8XFUD7yb040/j1L4oZbcKFIghdo=";
-          };
-
-          propagatedBuildInputs = with pkgs.python3Packages; [
-          ];
-
-          doCheck = false;
-        };
-
-        watchdog = pkgs.python3Packages.buildPythonPackage {
-          pname = "watchdog";
-          version = "6.0.0";
-          format = "setuptools";
-
-          src = pkgs.fetchPypi {
-            pname = "watchdog";
-            version = "6.0.0";
-            sha256 = "sha256-nd98gv2jro4k3s2hM47eZuHJmIPbk3Edj7lB6qLYwoI=";
-          };
-
-          propagatedBuildInputs = with pkgs.python3Packages; [
-          ];
-
-          doCheck = false;
-        };
-
-        lsprotocol = pkgs.python3Packages.buildPythonPackage {
-          pname = "lsprotocol";
-          version = "2024.0.0b1";
-          format = "wheel";
-
-          src = pkgs.fetchurl {
+          lsprotocol = buildWheel {
+            pname = "lsprotocol";
+            version = "2024.0.0b1";
             url = "https://files.pythonhosted.org/packages/4d/1b/526af91cd43eba22ac7d9dbdec729dd9d91c2ad335085a61dd42307a7b35/lsprotocol-2024.0.0b1-py3-none-any.whl";
             sha256 = "sha256-k3hQUKwVWuK+FrHr+9dMIU/rPT73exA5nOlB5czvbr0=";
+            propagatedBuildInputs = [
+              attrs
+              cattrs
+              jsonschema
+            ];
           };
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            attrs
-            cattrs
-            jsonschema
-          ];
-
-          doCheck = false;
-        };
-
-        pygls = pkgs.python3Packages.buildPythonPackage {
-          pname = "pygls";
-          version = "2.0.0a2";
-          format = "wheel";
-
-          src = pkgs.fetchurl {
+          pygls = buildWheel {
+            pname = "pygls";
+            version = "2.0.0a2";
             url = "https://files.pythonhosted.org/packages/f8/47/7d7b3911fbd27153ee38a1a15e3977c72733a41ee8d7f6ce6dca65843fe9/pygls-2.0.0a2-py3-none-any.whl";
             sha256 = "sha256-sgI2kyFAk0OqZEDXMRHZ+gwi5YBGb/HHaWuDWLuR8kM=";
+            propagatedBuildInputs = [ lsprotocol ];
           };
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            lsprotocol
-          ];
-
-          doCheck = false;
-        };
-
-        mdformat = pkgs.python3Packages.buildPythonPackage {
-          pname = "mdformat";
-          version = "0.7.19";
-          format = "wheel";
-
-          src = pkgs.fetchurl {
+          mdformat = buildWheel {
+            pname = "mdformat";
+            version = "0.7.19";
             url = "https://files.pythonhosted.org/packages/a5/7e/a7a904ec104e21c85333a02dd54456f53d5be31bee716217a1450844a044/mdformat-0.7.19-py3-none-any.whl";
             sha256 = "sha256-XDYJkq3BGM8Uecu+krs71m3NfxpaOirWZ1kVYixnjPE=";
+            propagatedBuildInputs = [ markdown-it-py ];
           };
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
-            markdown-it-py
-          ];
+          # PyPI packages that use setuptools/pyproject
+          py-markdown-table = buildPythonPackage {
+            pname = "py-markdown-table";
+            version = "1.2.0";
+            format = "pyproject";
+            src = fetchPypi {
+              pname = "py_markdown_table";
+              version = "1.2.0";
+              sha256 = "sha256-uuMMqX274UT/phiXlsi+1kWV6kyqTUI3nhFY3Y0myHM=";
+            };
+            nativeBuildInputs = [ poetry-core ];
+            doCheck = false;
+          };
 
-          doCheck = false;
+          tosholi = buildPythonPackage {
+            pname = "tosholi";
+            version = "0.1.0";
+            format = "pyproject";
+            src = fetchPypi {
+              pname = "tosholi";
+              version = "0.1.0";
+              sha256 = "sha256-MmykuNgxCzKvmei+c6O2Yosw88i027jnvGDkKiWpGlI=";
+            };
+            nativeBuildInputs = [
+              setuptools
+              setuptools_scm
+            ];
+            propagatedBuildInputs = [
+              dacite
+              tomli-w
+            ];
+            doCheck = false;
+          };
+
+          typing-extensions = buildPythonPackage {
+            pname = "typing_extensions";
+            version = "4.12.2";
+            format = "pyproject";
+            src = fetchPypi {
+              pname = "typing_extensions";
+              version = "4.12.2";
+              sha256 = "sha256-Gn6tVcflWd1N7ohW46iLQSJav+HOjfV7fBORX+Eh/7g=";
+            };
+            nativeBuildInputs = with pkgs.python3Packages; [
+              flit-core
+            ];
+            doCheck = false;
+          };
+
+          ripgrepy = buildPythonPackage {
+            pname = "ripgrepy";
+            version = "2.0.0";
+            format = "setuptools";
+            src = fetchPypi {
+              pname = "ripgrepy";
+              version = "2.0.0";
+              sha256 = "sha256-bdhxuv6FkwEJc1TR8XFUD7yb040/j1L4oZbcKFIghdo=";
+            };
+            doCheck = false;
+          };
+
+          watchdog = buildPythonPackage {
+            pname = "watchdog";
+            version = "6.0.0";
+            format = "setuptools";
+            src = fetchPypi {
+              pname = "watchdog";
+              version = "6.0.0";
+              sha256 = "sha256-nd98gv2jro4k3s2hM47eZuHJmIPbk3Edj7lB6qLYwoI=";
+            };
+            doCheck = false;
+          };
         };
       in
       {
         packages.default = pkgs.python3Packages.buildPythonPackage {
           pname = "bibli-ls";
           version = "0.1.6.2";
-
           src = ./.;
           format = "pyproject";
 
-          propagatedBuildInputs = with pkgs.python3Packages; [
+          propagatedBuildInputs = with customPythonPackages; [
             bibtexparser2
             watchdog
             pyzotero
@@ -208,8 +181,8 @@
 
           nativeBuildInputs = with pkgs.python3Packages; [
             setuptools
-            pip
-            wheel
+            # pip
+            # wheel
           ];
 
           doCheck = false;
@@ -217,8 +190,7 @@
           meta = with pkgs.lib; {
             description = "A simple LSP server for your bibliographies";
             homepage = "https://pypi.org/project/bibli-ls/";
-            license = licenses.mit; # Adjust according to your license
-            maintainers = with maintainers; [ ];
+            license = licenses.mit;
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,206 @@
+{
+  description = "A simple LSP server for your bibliographies";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        bibtexparser2 = pkgs.python3Packages.buildPythonPackage {
+          pname = "bibtexparser";
+          version = "2.0.0b4";
+          format = "wheel";
+
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/3f/64/6eda019a3b0d3aa6834865c126b66cfd442f56829befdca571c40662f8a6/bibtexparser-2.0.0b4-py3-none-any.whl";
+            sha256 = "sha256-FOWMfvltp4z2dce7LPFbA2E9Rj737c09ruIPU7SJzoM=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+
+        pyzotero = pkgs.python3Packages.buildPythonPackage {
+          pname = "pyzotero";
+          version = "1.5.25";
+          format = "wheel";
+
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/cb/3c/717f90930fbba6ec433a8b6eb9c8854089b7cd54118fb3dd5822d53bdfc7/pyzotero-1.5.25-py3-none-any.whl";
+            sha256 = "sha256-ZSkTDLfH53OWPZLbfnoYtpipesgVZ2YyC1Xr1MfpTtU=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            bibtexparser2
+            feedparser
+            pytz
+            requests
+          ];
+
+          doCheck = false;
+        };
+
+        py-markdown-table = pkgs.python3Packages.buildPythonPackage {
+          pname = "py-markdown-table";
+          version = "1.2.0";
+          format = "pyproject";
+
+          src = pkgs.fetchPypi {
+            pname = "py_markdown_table";
+            version = "1.2.0";
+            sha256 = "sha256-uuMMqX274UT/phiXlsi+1kWV6kyqTUI3nhFY3Y0myHM=";
+          };
+
+          nativeBuildInputs = with pkgs.python3Packages; [
+            poetry-core
+          ];
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+
+        tosholi = pkgs.python3Packages.buildPythonPackage {
+          pname = "tosholi";
+          version = "0.1.0";
+          format = "pyproject";
+
+          src = pkgs.fetchPypi {
+            pname = "tosholi";
+            version = "0.1.0";
+            sha256 = "sha256-MmykuNgxCzKvmei+c6O2Yosw88i027jnvGDkKiWpGlI=";
+          };
+
+          nativeBuildInputs = with pkgs.python3Packages; [
+            setuptools
+            setuptools_scm
+          ];
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            dacite
+            tomli-w
+          ];
+
+          doCheck = false;
+        };
+
+        ripgrepy = pkgs.python3Packages.buildPythonPackage {
+          pname = "ripgrepy";
+          version = "2.0.0";
+          format = "setuptools";
+
+          src = pkgs.fetchPypi {
+            pname = "ripgrepy";
+            version = "2.0.0";
+            sha256 = "sha256-bdhxuv6FkwEJc1TR8XFUD7yb040/j1L4oZbcKFIghdo=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+
+        watchdog = pkgs.python3Packages.buildPythonPackage {
+          pname = "watchdog";
+          version = "6.0.0";
+          format = "setuptools";
+
+          src = pkgs.fetchPypi {
+            pname = "watchdog";
+            version = "6.0.0";
+            sha256 = "sha256-nd98gv2jro4k3s2hM47eZuHJmIPbk3Edj7lB6qLYwoI=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+
+        pygls = pkgs.python3Packages.buildPythonPackage {
+          pname = "pygls";
+          version = "2.0.0a2";
+          format = "wheel";
+
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/f8/47/7d7b3911fbd27153ee38a1a15e3977c72733a41ee8d7f6ce6dca65843fe9/pygls-2.0.0a2-py3-none-any.whl";
+            sha256 = "sha256-sgI2kyFAk0OqZEDXMRHZ+gwi5YBGb/HHaWuDWLuR8kM=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+
+        mdformat = pkgs.python3Packages.buildPythonPackage {
+          pname = "mdformat";
+          version = "0.7.19";
+          format = "wheel";
+
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/a5/7e/a7a904ec104e21c85333a02dd54456f53d5be31bee716217a1450844a044/mdformat-0.7.19-py3-none-any.whl";
+            sha256 = "sha256-XDYJkq3BGM8Uecu+krs71m3NfxpaOirWZ1kVYixnjPE=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+          ];
+
+          doCheck = false;
+        };
+      in
+      {
+        packages.default = pkgs.python3Packages.buildPythonPackage {
+          pname = "bibli-ls";
+          version = "0.1.6.2";
+
+          src = ./.;
+          format = "pyproject";
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            bibtexparser2
+            watchdog
+            pyzotero
+            py-markdown-table
+            pygls
+            tosholi
+            mdformat
+            ripgrepy
+            typing-extensions
+          ];
+
+          nativeBuildInputs = with pkgs.python3Packages; [
+            setuptools
+            pip
+            wheel
+          ];
+
+          doCheck = false;
+
+          meta = with pkgs.lib; {
+            description = "A simple LSP server for your bibliographies";
+            homepage = "https://pypi.org/project/bibli-ls/";
+            license = licenses.mit; # Adjust according to your license
+            maintainers = with maintainers; [ ];
+          };
+        };
+
+        defaultPackage = self.packages.${system}.default;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           };
 
           propagatedBuildInputs = with pkgs.python3Packages; [
+            pylatexenc
           ];
 
           doCheck = false;
@@ -132,6 +133,25 @@
           doCheck = false;
         };
 
+        lsprotocol = pkgs.python3Packages.buildPythonPackage {
+          pname = "lsprotocol";
+          version = "2024.0.0b1";
+          format = "wheel";
+
+          src = pkgs.fetchurl {
+            url = "https://files.pythonhosted.org/packages/4d/1b/526af91cd43eba22ac7d9dbdec729dd9d91c2ad335085a61dd42307a7b35/lsprotocol-2024.0.0b1-py3-none-any.whl";
+            sha256 = "sha256-k3hQUKwVWuK+FrHr+9dMIU/rPT73exA5nOlB5czvbr0=";
+          };
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            attrs
+            cattrs
+            jsonschema
+          ];
+
+          doCheck = false;
+        };
+
         pygls = pkgs.python3Packages.buildPythonPackage {
           pname = "pygls";
           version = "2.0.0a2";
@@ -143,6 +163,7 @@
           };
 
           propagatedBuildInputs = with pkgs.python3Packages; [
+            lsprotocol
           ];
 
           doCheck = false;
@@ -159,6 +180,7 @@
           };
 
           propagatedBuildInputs = with pkgs.python3Packages; [
+            markdown-it-py
           ];
 
           doCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -35,38 +35,38 @@
             doCheck = false;
           };
 
+        lsprotocol = buildWheel {
+          pname = "lsprotocol";
+          version = "2024.0.0b1";
+          url = "https://files.pythonhosted.org/packages/4d/1b/526af91cd43eba22ac7d9dbdec729dd9d91c2ad335085a61dd42307a7b35/lsprotocol-2024.0.0b1-py3-none-any.whl";
+          sha256 = "sha256-k3hQUKwVWuK+FrHr+9dMIU/rPT73exA5nOlB5czvbr0=";
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            attrs
+            cattrs
+            jsonschema
+          ];
+        };
+
+        bibtexparser2 = buildWheel {
+          pname = "bibtexparser";
+          version = "2.0.0b4";
+          url = "https://files.pythonhosted.org/packages/3f/64/6eda019a3b0d3aa6834865c126b66cfd442f56829befdca571c40662f8a6/bibtexparser-2.0.0b4-py3-none-any.whl";
+          sha256 = "sha256-FOWMfvltp4z2dce7LPFbA2E9Rj737c09ruIPU7SJzoM=";
+          propagatedBuildInputs = with pkgs.python3Packages; [ pylatexenc ];
+        };
+
         # Custom Python packages
         customPythonPackages = with pkgs.python3Packages; {
-          bibtexparser2 = buildWheel {
-            pname = "bibtexparser";
-            version = "2.0.0b4";
-            url = "https://files.pythonhosted.org/packages/3f/64/6eda019a3b0d3aa6834865c126b66cfd442f56829befdca571c40662f8a6/bibtexparser-2.0.0b4-py3-none-any.whl";
-            sha256 = "sha256-FOWMfvltp4z2dce7LPFbA2E9Rj737c09ruIPU7SJzoM=";
-            propagatedBuildInputs = [ pylatexenc ];
-          };
-
           pyzotero = buildWheel {
             pname = "pyzotero";
             version = "1.5.25";
             url = "https://files.pythonhosted.org/packages/cb/3c/717f90930fbba6ec433a8b6eb9c8854089b7cd54118fb3dd5822d53bdfc7/pyzotero-1.5.25-py3-none-any.whl";
             sha256 = "sha256-ZSkTDLfH53OWPZLbfnoYtpipesgVZ2YyC1Xr1MfpTtU=";
             propagatedBuildInputs = [
-              # bibtexparser2
+              bibtexparser2
               feedparser
               pytz
               requests
-            ];
-          };
-
-          lsprotocol = buildWheel {
-            pname = "lsprotocol";
-            version = "2024.0.0b1";
-            url = "https://files.pythonhosted.org/packages/4d/1b/526af91cd43eba22ac7d9dbdec729dd9d91c2ad335085a61dd42307a7b35/lsprotocol-2024.0.0b1-py3-none-any.whl";
-            sha256 = "sha256-k3hQUKwVWuK+FrHr+9dMIU/rPT73exA5nOlB5czvbr0=";
-            propagatedBuildInputs = [
-              attrs
-              cattrs
-              jsonschema
             ];
           };
 


### PR DESCRIPTION
Hi!

I saw your LSP when looking at `zk`. First of all, a huge thank-you! It's very useful!
I use nix, so Python packages cannot be installed through the normal `pip install` way.
Therefore, I created a `flake.nix` file which simply defines dependencies and allows to install `bibli-ls` :+1: 

There are quite a lot of manually pinned dependencies because:
1. Most of your dependencies are above the ones that are referenced in `nixpkgs`,
2. Those are quite strictly pinned in your `pyproject.toml`.

Tested locally, it's working very well!

For the sake of reference in a working NixOS config:

- [Declaration of `bibli-ls` as an input](https://github.com/clementpoiret/nixos-config/blob/f1f7b3fc1637586707a07f21d5564558c0591141/flake.nix#L70),
- [Installation of `bibli-ls` as a home package](https://github.com/clementpoiret/nixos-config/blob/f1f7b3fc1637586707a07f21d5564558c0591141/modules/home/nvim/nvim.nix#L31),
- [Declarative `.blibli.toml` using a home file](https://github.com/clementpoiret/nixos-config/blob/f1f7b3fc1637586707a07f21d5564558c0591141/modules/home/zk/zk.nix#L25).

Hope you'll find this PR helpful :)